### PR TITLE
docs: add community v2 wrapper to install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The Bucket Protocol TypeScript SDK is a comprehensive development toolkit for in
 ```bash
 npm install @mysten/sui  # >= 2.0.0
 npm install @mysten/bcs  # >= 2.0.0
-npm install @bucket-protocol/sdk
+npm install @bucket-protocol/sdk && npm install bucket-protocol-sdk-v2@latest
 ```
 
 ## Quick Start


### PR DESCRIPTION
The unscoped `bucket-protocol-sdk` is deprecated. This adds the community‑maintained `bucket-protocol-sdk-v2` (drop‑in replacement) to the README install instructions to help users avoid build issues with newer `@mysten/sui` releases.