### PR TITLE
chore: use ADMIN_TOKEN for publish workflow checkout

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
-          token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.ADMIN_TOKEN }}
       - name: Install pnpm
         uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v5


### PR DESCRIPTION
## Summary
- Replace `secrets.PAT || secrets.GITHUB_TOKEN` with `secrets.ADMIN_TOKEN` for the checkout step in `.github/workflows/publish.yml` so workflow-initiated pushes use the dedicated admin credential.

## Test plan
- [ ] Confirm `ADMIN_TOKEN` is configured in repository secrets
- [ ] Trigger the publish workflow and verify checkout succeeds
- [ ] Verify any workflow-initiated pushes/tags propagate as expected

Generated with [Claude Code](https://claude.com/claude-code)